### PR TITLE
Investigate api upload 405 error on vps

### DIFF
--- a/Server/routes/acryliccustomize.js
+++ b/Server/routes/acryliccustomize.js
@@ -11,6 +11,23 @@ import {
 
 const router = express.Router();
 
+// 🐛 DEBUG: Simple test route to verify routing works
+router.get("/test", (req, res) => {
+  res.json({ 
+    message: "Acrylic customize route is working", 
+    method: req.method,
+    timestamp: new Date().toISOString() 
+  });
+});
+
+router.post("/upload/test", (req, res) => {
+  res.json({ 
+    message: "POST method works on acrylic customize", 
+    method: req.method,
+    timestamp: new Date().toISOString() 
+  });
+});
+
 router.post("/", upload.single("image"), createAcrylic);
 router.get("/", getAllAcrylic);
 router.get("/:id", getAcrylicById);

--- a/Server/server.js
+++ b/Server/server.js
@@ -32,6 +32,12 @@ app.use(cors());
 app.use(express.json({ limit: "50mb" }));
 app.use(express.urlencoded({ extended: true, limit: "50mb" }));
 
+// 🐛 DEBUG: Log all incoming requests (add this for debugging)
+app.use((req, res, next) => {
+  console.log(`${new Date().toISOString()} - ${req.method} ${req.originalUrl} - Headers: ${JSON.stringify(req.headers)}`);
+  next();
+});
+
 // ✅ Serve static files
 app.use("/newarrivalsUploads", express.static(path.join(__dirname, "newarrivalsUploads")));
 app.use("/addtocartUploads", express.static(path.join(__dirname, "addtocartUploads")));


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add debugging middleware and test routes to diagnose a 405 "Method Not Allowed" error on VPS.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The 405 error is occurring on a VPS but not locally, suggesting a web server configuration issue (e.g., Nginx/Apache) rather than a code bug. These additions will help verify if requests are reaching the Node.js server and if specific methods are being blocked before the application layer.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a8de27e-d559-4d83-b468-3e7c5c662467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7a8de27e-d559-4d83-b468-3e7c5c662467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>