### PR TITLE
Handle razorpay receipt length error

### DIFF
--- a/Server/controllers/paymentController.js
+++ b/Server/controllers/paymentController.js
@@ -8,8 +8,11 @@ export const createOrder = async (req, res) => {
   try {
     const { amount, cartItemId, productType, deliveryDetails } = req.body;
     
-    // Generate a unique receipt ID using cart item ID and timestamp
-    const receipt = `receipt_${cartItemId}_${Date.now()}`;
+    // Generate a unique receipt ID (max 40 chars for Razorpay)
+    // Use a shorter timestamp and truncate cartItemId if needed
+    const shortTimestamp = Date.now().toString().slice(-8); // Last 8 digits
+    const shortCartId = cartItemId.toString().slice(0, 20); // Max 20 chars
+    const receipt = `rcpt_${shortCartId}_${shortTimestamp}`;
 
     const options = {
       amount: amount * 100, // ₹ to paisa


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Shorten Razorpay receipt ID generation to comply with the 40-character limit.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous receipt format `receipt_${cartItemId}_${Date.now()}` exceeded Razorpay's 40-character limit, causing `BAD_REQUEST_ERROR`. The new format `rcpt_${shortCartId}_${shortTimestamp}` uses a shorter prefix, truncates the timestamp to 8 digits, and limits the cartItemId to 20 characters, ensuring the total length is at most 33 characters.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a3565d8-e542-44be-9728-04cfc685def8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a3565d8-e542-44be-9728-04cfc685def8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>